### PR TITLE
Fixup: Make jump to frame work again

### DIFF
--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -213,7 +213,7 @@ local frames = function(opts)
         local selection = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
 
-        session:_frame_set(entry.value)
+        session:_frame_set(selection.value)
       end)
 
       return true


### PR DESCRIPTION
This function wasn't working anymore after the recent refactor.

Also the entry selection now has an offset by one (selection will be one entry before the one you selected). Dunno whether this is a telescope problem.