### PR TITLE
Bug fix: not all frames have a source attached

### DIFF
--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -201,7 +201,7 @@ local frames = function(opts)
           value = frame,
           display = frame.name,
           ordinal = frame.name,
-          filename = frame.source.path,
+          filename = frame.source and frame.source.path or '',
           lnum = frame.line or 1,
           col = frame.column or 0,
         }


### PR DESCRIPTION
Not all frames have  a source file attached (e.g. some Java bytecode, code compiled without -g)