### PR TITLE
Add support for loading launch.json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,16 @@ require'telescope'.extensions.dap.list_breakpoints{}
 require'telescope'.extensions.dap.variables{}
 require'telescope'.extensions.dap.frames{}
 ```
+
+## Launch.json support
+
+`Telescope dap configurations` supports `launch.json` (as in VSCode). Any
+configurations loaded from a `launch.json` file will be appended to the list
+obtained from `dap.configurations`. See [VSCode
+docs](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations)
+for `launch.json` format.
+
+```viml
+:Telescope dap configuration load_from_file=true " load configs from .vscode/launch.json
+:Telescope dap configuration load_from_file=path/to/launch.json " load configs from path/to/launch.json
+```

--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -69,6 +69,20 @@ local configurations = function(opts)
     end
   end
 
+  if opts.load_from_file then
+    local path = type(opts.load_from_file) == 'string' and
+      opts.load_from_file or
+      '.vscode/launch.json'
+    if vim.fn.filereadable(path) == 1 then
+      local file = vim.fn.readfile(path)
+      local json = vim.fn.json_decode(file)
+      assert(json.configurations, "launch.json must have a 'configurations' key")
+      for _, config in ipairs(json.configurations) do
+        table.insert(results, config)
+      end
+    end
+  end
+
   if vim.tbl_isempty(results) then
     return
   end


### PR DESCRIPTION
This PR adds support for loading additional configurations from a launch.json file. Useful for project-local debugger configurations.