### PR TITLE
feat: Support a custom config

### DIFF
--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -95,7 +95,11 @@ local configurations = function(opts)
         local selection = action_state.get_selected_entry()
         actions.close(prompt_bufnr)
 
-        dap.run(selection.value)
+        if selection.value.request == "custom" then
+          vim.cmd(selection.value.command)
+        else
+          dap.run(selection.value)
+        end
       end)
 
       return true


### PR DESCRIPTION
**Why** is the change needed?

I use an external library for some dap operations, and it's nice to be
able to execute it from the list of configurations.

My usage:

https://github.com/JRasmusBm/dotfiles/blob/e62f7027c07e3d71a849e0edad4967d2bb0ee05f/vim/lua/jrasmusbm/dap/python.lua#L30-L35

```lua
dap.configurations.python = {
  -- ...
  {
    type = "python",
    request = "custom",
    name = "Attach to debugger",
    command = "Debugpy attach 0.0.0.0 5678"
  },
 -- ...
}
```