### PR TITLE
Add highlight for subtle frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ require'telescope'.extensions.dap.list_breakpoints{}
 require'telescope'.extensions.dap.variables{}
 require'telescope'.extensions.dap.frames{}
 ```
+
+## Customize Colors
+
+Stack frames coming from external code (libraries) are highlighted with the "NvimDapSubtleFrame" highlight group (by default linked to "Comment").

--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -199,7 +199,12 @@ local frames = function(opts)
       entry_maker = function(frame)
         return {
           value = frame,
-          display = frame.name,
+          display = function ()
+            if frame.presentationHint == 'subtle' or not frame.source then
+              return frame.name, { { {0, #frame.name}, 'NvimDapSubtleFrame' } }
+            end
+            return frame.name
+          end,
           ordinal = frame.name,
           filename = frame.source and frame.source.path or '',
           lnum = frame.line or 1,
@@ -224,6 +229,8 @@ end
 
 return telescope.register_extension {
   setup = function()
+    vim.cmd [[ highlight default link NvimDapSubtleFrame Comment ]]
+
     require('dap.ui').pick_one = function(items, prompt, label_fn, cb)
       local opts = {}
       pickers.new(opts, {


### PR DESCRIPTION
This PR adds a highlight group for subtle frames (frames that are from third party libraries most of the time). This highlight group is also used for frames where no source is defined (for debuggers that don't set the subtle hint).

![image](https://user-images.githubusercontent.com/32224410/164908966-81dd8621-c5b2-41c8-8109-03ab3ebb262d.png)
