### PR TITLE
Add option to disable overwriting the dap internal ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ require('telescope').load_extension('dap')
 
 somewhere after your require('telescope').setup() call.
 
+If you want to disable overwriting the `dap` internal ui, for example because you already use a different plugin to overwrite `vim.ui.select`,
+you can do so by configuring the extension as part of the telescope setup.
+
+```lua
+require('telescope').setup({
+  extensions = {
+    dap = {
+      overwrite_pick_one = false
+    }
+  }
+})
+```
+
 ## Available commands
 
 ```viml

--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -234,36 +234,36 @@ return telescope.register_extension {
   setup = function(ext_config)
     vim.cmd [[ highlight default link NvimDapSubtleFrame Comment ]]
 
-    overwrite_pick_one = vim.F.if_nil(ext_config.overwrite_pick_one, false)
+    if not vim.F.if_nil(ext_config.overwrite_pick_one, false) then
+      return
+    end
 
-    if overwrite_pick_one then
-      require('dap.ui').pick_one = function(items, prompt, label_fn, cb)
-        local opts = {}
-        pickers.new(opts, {
-          prompt_title = prompt,
-          finder    = finders.new_table {
-            results = items,
-            entry_maker = function(entry)
-              return {
-                value = entry,
-                display = label_fn(entry),
-                ordinal = label_fn(entry),
-              }
-            end,
-          },
-          sorter = conf.generic_sorter(opts),
-          attach_mappings = function(prompt_bufnr)
-            actions.select_default:replace(function()
-              local selection = action_state.get_selected_entry()
-              actions.close(prompt_bufnr)
-
-              cb(selection.value)
-            end)
-
-            return true
+    require('dap.ui').pick_one = function(items, prompt, label_fn, cb)
+      local opts = {}
+      pickers.new(opts, {
+        prompt_title = prompt,
+        finder    = finders.new_table {
+          results = items,
+          entry_maker = function(entry)
+            return {
+              value = entry,
+              display = label_fn(entry),
+              ordinal = label_fn(entry),
+            }
           end,
-        }):find()
-      end
+        },
+        sorter = conf.generic_sorter(opts),
+        attach_mappings = function(prompt_bufnr)
+          actions.select_default:replace(function()
+            local selection = action_state.get_selected_entry()
+            actions.close(prompt_bufnr)
+
+            cb(selection.value)
+          end)
+
+          return true
+        end,
+      }):find()
     end
   end,
   exports = {

--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -237,7 +237,7 @@ return telescope.register_extension {
   setup = function(ext_config)
     vim.cmd [[ highlight default link NvimDapSubtleFrame Comment ]]
 
-    if not vim.F.if_nil(ext_config.overwrite_pick_one, false) then
+    if not vim.F.if_nil(ext_config.overwrite_pick_one, true) then
       return
     end
 

--- a/lua/telescope/_extensions/dap.lua
+++ b/lua/telescope/_extensions/dap.lua
@@ -231,35 +231,39 @@ local frames = function(opts)
 end
 
 return telescope.register_extension {
-  setup = function()
+  setup = function(ext_config)
     vim.cmd [[ highlight default link NvimDapSubtleFrame Comment ]]
 
-    require('dap.ui').pick_one = function(items, prompt, label_fn, cb)
-      local opts = {}
-      pickers.new(opts, {
-        prompt_title = prompt,
-        finder    = finders.new_table {
-          results = items,
-          entry_maker = function(entry)
-            return {
-              value = entry,
-              display = label_fn(entry),
-              ordinal = label_fn(entry),
-            }
+    overwrite_pick_one = vim.F.if_nil(ext_config.overwrite_pick_one, false)
+
+    if overwrite_pick_one then
+      require('dap.ui').pick_one = function(items, prompt, label_fn, cb)
+        local opts = {}
+        pickers.new(opts, {
+          prompt_title = prompt,
+          finder    = finders.new_table {
+            results = items,
+            entry_maker = function(entry)
+              return {
+                value = entry,
+                display = label_fn(entry),
+                ordinal = label_fn(entry),
+              }
+            end,
+          },
+          sorter = conf.generic_sorter(opts),
+          attach_mappings = function(prompt_bufnr)
+            actions.select_default:replace(function()
+              local selection = action_state.get_selected_entry()
+              actions.close(prompt_bufnr)
+
+              cb(selection.value)
+            end)
+
+            return true
           end,
-        },
-        sorter = conf.generic_sorter(opts),
-        attach_mappings = function(prompt_bufnr)
-          actions.select_default:replace(function()
-            local selection = action_state.get_selected_entry()
-            actions.close(prompt_bufnr)
-
-            cb(selection.value)
-          end)
-
-          return true
-        end,
-      }):find()
+        }):find()
+      end
     end
   end,
   exports = {


### PR DESCRIPTION
Hello, 

thank you for writing and maintaining this very useful plugin. I would like to make one improvement.

I'm using [dressing.nvim](https://github.com/stevearc/dressing.nvim) that already overwrites `vim.ui.select` so I don’t need this plugin to overwrite the internal ui once more. 

This PR adds an option to disable overwriting the internal ui. I also updated the README.md to reflect this.